### PR TITLE
fix: Commands wont be suggested due to client-sided NPE

### DIFF
--- a/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
+++ b/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
@@ -84,7 +84,7 @@ public class ConfigCommand implements ICommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private int executeConfigList(CommandContext<CommandSourceStack> cc, ConfigKeys key) {
+    private int executeConfigList(CommandContext<CommandSourceStack> cc, ConfigListKeys key) {
         CommandUtils.sendMessage(cc, "Values in " + key + ":\n" + String.join(", ", key.config.get()));
 
         return Command.SINGLE_SUCCESS;

--- a/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
+++ b/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
@@ -28,7 +28,7 @@ public class ConfigCommand implements ICommand {
 
         final ForgeConfigSpec.ConfigValue<List<? extends String>> config;
 
-        ConfigKeys(ForgeConfigSpec.ConfigValue<List<? extends String>> config) {
+        ConfigListKeys(ForgeConfigSpec.ConfigValue<List<? extends String>> config) {
             this.config = config;
         }
     }

--- a/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
+++ b/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
@@ -102,7 +102,7 @@ public class ConfigCommand implements ICommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private int executeRemove(CommandContext<CommandSourceStack> cc, ConfigKeys key) {
+    private int executeRemove(CommandContext<CommandSourceStack> cc, ConfigListKeys key) {
         var newList = new ArrayList<>(key.config.get().stream().map(String::toString).toList());
         var value = cc.getArgument("value", String.class);
         newList.remove(value);

--- a/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
+++ b/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
@@ -90,7 +90,7 @@ public class ConfigCommand implements ICommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private int executeAdd(CommandContext<CommandSourceStack> cc, ConfigKeys key) {
+    private int executeAdd(CommandContext<CommandSourceStack> cc, ConfigListKeys key) {
         var newList = new ArrayList<>(key.config.get().stream().map(String::toString).toList());
         var value = cc.getArgument("value", String.class);
         newList.add(value);

--- a/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
+++ b/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
@@ -38,7 +38,7 @@ public class ConfigCommand implements ICommand {
         var list = Commands.literal("list")
                 .executes(this::executeList);
 
-        for (var key : ConfigKeys.values()) {
+        for (var key : ConfigListKeys.values()) {
             list.then(Commands.literal(key.toString())
                     .then(Commands.literal("add")
                             .then(Commands.argument("value", StringArgumentType.string())

--- a/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
+++ b/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ConfigCommand implements ICommand {
-    private enum ConfigKeys {
+    private enum ConfigListKeys {
         block_white_list(SVMMConfig.BLOCK_WHITELIST),
         block_black_list(SVMMConfig.BLOCK_BLACKLIST),
         giant_vein_starter_ore(SVMMConfig.GIANT_VEIN_STARTER_BLOCKS),

--- a/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
+++ b/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
@@ -6,12 +6,9 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
 import dev.tourmi.svmm.config.SVMMConfig;
 import dev.tourmi.svmm.utils.CommandUtils;
-import net.minecraft.commands.Commands;
 import net.minecraft.commands.CommandSourceStack;
-import net.minecraft.commands.arguments.StringRepresentableArgument;
-import net.minecraft.util.StringRepresentable;
+import net.minecraft.commands.Commands;
 import net.minecraftforge.common.ForgeConfigSpec;
-import net.minecraftforge.server.command.EnumArgument;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,31 +17,42 @@ import java.util.stream.Collectors;
 
 public class ConfigCommand implements ICommand {
     private enum ConfigKeys {
-        block_white_list,
-        block_black_list,
-        giant_vein_starter_ore,
-        giant_vein_whitelist,
-        giant_vein_blacklist,
-        tunneling_whitelist,
-        tunneling_blacklist,
-        force_blacklist
+        block_white_list(SVMMConfig.BLOCK_WHITELIST),
+        block_black_list(SVMMConfig.BLOCK_BLACKLIST),
+        giant_vein_starter_ore(SVMMConfig.GIANT_VEIN_STARTER_BLOCKS),
+        giant_vein_whitelist(SVMMConfig.GIANT_VEIN_WHITELIST),
+        giant_vein_blacklist(SVMMConfig.GIANT_VEIN_BLACKLIST),
+        tunneling_whitelist(SVMMConfig.TUNNELING_WHITELIST),
+        tunneling_blacklist(SVMMConfig.TUNNELING_BLACKLIST),
+        force_blacklist(SVMMConfig.FORCE_BLACKLIST);
+
+        final ForgeConfigSpec.ConfigValue<List<? extends String>> config;
+
+        ConfigKeys(ForgeConfigSpec.ConfigValue<List<? extends String>> config) {
+            this.config = config;
+        }
     }
 
     @Override
     public LiteralArgumentBuilder<CommandSourceStack> getCommand() {
+        var list = Commands.literal("list")
+                .executes(this::executeList);
+
+        for (var key : ConfigKeys.values()) {
+            list.then(Commands.literal(key.toString())
+                    .then(Commands.literal("add")
+                            .then(Commands.argument("value", StringArgumentType.string())
+                                    .executes(ctx -> this.executeAdd(ctx, key)))) // /svmm config list {configKey} add {value}
+                    .then(Commands.literal("remove")
+                            .then(Commands.argument("value", StringArgumentType.string())
+                                    .executes(ctx -> this.executeRemove(ctx, key)))) // /svmm config list {configKey} remove {value}
+                    .executes(ctx -> this.executeConfigList(ctx, key))); // /svmm config list {configKey}
+        }
+
         return Commands.literal("config")
                 .requires(cs -> !SVMMConfig.RUNTIME_CONFIG_DISABLED.get())
                 .requires(CommandUtils::isModerator)
-                .then(Commands.literal("list")
-                    .then(Commands.argument("configKey", EnumArgument.enumArgument(ConfigKeys.class))
-                        .then(Commands.literal("add")
-                                .then(Commands.argument("value", StringArgumentType.string())
-                                    .executes(this::executeAdd))) // /svmm config list {configKey} add {value}
-                        .then(Commands.literal("remove")
-                                .then(Commands.argument("value", StringArgumentType.string())
-                                    .executes(this::executeRemove))) // /svmm config list {configKey} remove {value}
-                        .executes(this::executeConfigList)) // /svmm config list {configKey}
-                    .executes(this::executeList)) // /svmm config list
+                .then(list) // /svmm config list
                 .executes(this::defaultExecute); // /svmm config
     }
 
@@ -76,54 +84,33 @@ public class ConfigCommand implements ICommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private int executeConfigList(CommandContext<CommandSourceStack> cc) {
-        var key = cc.getArgument("configKey", ConfigKeys.class);
-        var config = GetListConfig(key);
-        CommandUtils.sendMessage(cc, "Values in " + key + ":\n" + String.join(", ", config.get()));
+    private int executeConfigList(CommandContext<CommandSourceStack> cc, ConfigKeys key) {
+        CommandUtils.sendMessage(cc, "Values in " + key + ":\n" + String.join(", ", key.config.get()));
 
         return Command.SINGLE_SUCCESS;
     }
 
-    private int executeAdd(CommandContext<CommandSourceStack> cc) {
-        var key = cc.getArgument("configKey", ConfigKeys.class);
-        var config = GetListConfig(key);
-
-        var newList = new ArrayList<>(config.get().stream().map(String::toString).toList());
+    private int executeAdd(CommandContext<CommandSourceStack> cc, ConfigKeys key) {
+        var newList = new ArrayList<>(key.config.get().stream().map(String::toString).toList());
         var value = cc.getArgument("value", String.class);
         newList.add(value);
-        config.set(newList);
-        config.save();
+        key.config.set(newList);
+        key.config.save();
 
         CommandUtils.sendMessage(cc, "Successfully added " + value + " to " + key.name() + " list");
 
         return Command.SINGLE_SUCCESS;
     }
 
-    private int executeRemove(CommandContext<CommandSourceStack> cc) {
-        var key = cc.getArgument("configKey", ConfigKeys.class);
-        var config = GetListConfig(key);
-
-        var newList = new ArrayList<>(config.get().stream().map(String::toString).toList());
+    private int executeRemove(CommandContext<CommandSourceStack> cc, ConfigKeys key) {
+        var newList = new ArrayList<>(key.config.get().stream().map(String::toString).toList());
         var value = cc.getArgument("value", String.class);
         newList.remove(value);
-        config.set(newList);
-        config.save();
+        key.config.set(newList);
+        key.config.save();
 
         CommandUtils.sendMessage(cc, "Successfully removed " + value + " from " + key.name() + " list");
 
         return Command.SINGLE_SUCCESS;
-    }
-
-    private ForgeConfigSpec.ConfigValue<List<? extends String>> GetListConfig(ConfigKeys key) {
-        return switch (key) {
-            case block_white_list -> SVMMConfig.BLOCK_WHITELIST;
-            case block_black_list -> SVMMConfig.BLOCK_BLACKLIST;
-            case giant_vein_starter_ore -> SVMMConfig.GIANT_VEIN_STARTER_BLOCKS;
-            case giant_vein_whitelist -> SVMMConfig.GIANT_VEIN_WHITELIST;
-            case giant_vein_blacklist -> SVMMConfig.GIANT_VEIN_BLACKLIST;
-            case tunneling_whitelist -> SVMMConfig.TUNNELING_WHITELIST;
-            case tunneling_blacklist -> SVMMConfig.TUNNELING_BLACKLIST;
-            case force_blacklist -> SVMMConfig.FORCE_BLACKLIST;
-        };
     }
 }

--- a/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
+++ b/src/main/java/dev/tourmi/svmm/commands/ConfigCommand.java
@@ -80,7 +80,7 @@ public class ConfigCommand implements ICommand {
 
     private int executeList(CommandContext<CommandSourceStack> cc) {
         CommandUtils.sendMessage(cc, "Available configuration keys");
-        CommandUtils.sendMessage(cc, Arrays.stream(ConfigKeys.values()).map(Enum::name).collect(Collectors.joining(", ")));
+        CommandUtils.sendMessage(cc, Arrays.stream(ConfigListKeys.values()).map(Enum::name).collect(Collectors.joining(", ")));
         return Command.SINGLE_SUCCESS;
     }
 


### PR DESCRIPTION
This PR fixes #22.
An EnumArgument is instantiated with ConfigKeys enum class, but clients do not have that class, you know.
Because of this, a NullPointerException occurs in client-side.